### PR TITLE
Add a new label kind/proposal

### DIFF
--- a/ks-ci-bot/OWNERS
+++ b/ks-ci-bot/OWNERS
@@ -6,3 +6,4 @@ reviewers:
  - wnxn
  - zryfish
  - magicsong
+ - linuxsuren

--- a/ks-ci-bot/labels.yaml
+++ b/ks-ci-bot/labels.yaml
@@ -76,6 +76,12 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - color: bfdadc
+      description: Categorizes issue as related to a proposal.
+      name: kind/proposal
+      target: issues
+      prowPlugin: label
+      addedBy: anyone
     - color: 15dd18
       description: Indicates that a PR is ready to be merged.
       name: lgtm


### PR DESCRIPTION
There're some proposals in the GitHub org kubesphere. With lable kind/propsoal, we can get a whole list of them.
