### PR TITLE
Set merge method as squash for repo community and ks-jenkins

### DIFF
--- a/ks-ci-bot/config.yaml
+++ b/ks-ci-bot/config.yaml
@@ -20,6 +20,9 @@ tide:
     kubesphere/s2ioperator: squash
     kubesphere/porter: squash
     kubesphere/s2irun: squash
+    kubesphere/community: squash
+    kubesphere/ks-jenkins: squash
+    kubesphere/prow-tutorial: squash
     yunify/qingcloud-cloud-controller-manager: squash
     yunify/hostnic-cni: squash
   target_url: https://prow.kubesphere.io


### PR DESCRIPTION
Actually, I'd like to suggest that the squash merge method be the default behavior. Normally, we should only commit one feature or bugfix in one PR.