### PR TITLE
Add linuxsuren as a owner of the directory ks-ci-bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 kubeconfig
+.idea/

--- a/ks-ci-bot/OWNERS
+++ b/ks-ci-bot/OWNERS
@@ -1,6 +1,7 @@
 approvers:
  - wnxn
  - zryfish
+ - linuxsuren
 
 reviewers:
  - wnxn


### PR DESCRIPTION
@linuxsuren is a member of KubeSphere DevOps. And he did a bunch of contribution on this repository.
Please see https://github.com/kubesphere/prow-tutorial/pulls?q=is%3Apr+author%3ALinuxSuRen+is%3Aclosed
