### PR TITLE
Add prow plugin stage

### DIFF
--- a/ks-ci-bot/plugins.yaml
+++ b/ks-ci-bot/plugins.yaml
@@ -15,6 +15,7 @@ plugins:
   - project-manager
   - help
   - retitle
+  - stage
   kubesphere/devops-java-sample:
   - assign
   - size
@@ -47,6 +48,7 @@ plugins:
   - project-manager
   - help
   - retitle
+  - stage
   kubesphere/kubekey:
   - assign
   - size
@@ -63,6 +65,7 @@ plugins:
   - project-manager
   - help
   - retitle
+  - stage
   kubesphere/community:
   - assign
   - size
@@ -80,6 +83,7 @@ plugins:
   - project-manager
   - help
   - retitle
+  - stage
   kubesphere/console:
   - assign
   - size
@@ -206,6 +210,7 @@ plugins:
   - project-manager
   - help
   - retitle
+  - stage
   kubesphere/porter:
   - assign
   - size
@@ -262,6 +267,7 @@ plugins:
   - project
   - project-manager
   - retitle
+  - stage
   kubesphere/s2irun:
   - assign
   - size
@@ -277,6 +283,7 @@ plugins:
   - project-manager
   - help
   - retitle
+  - stage
   kubesphere/ks-jenkins:
   - assign
   - size
@@ -292,6 +299,7 @@ plugins:
   - project-manager
   - help
   - retitle
+  - stage
 repo_milestone:
   # Default maintainer
   '':


### PR DESCRIPTION
Label the stage of an issue as alpha/beta/stable

This is useful especially when someone wants to start a big proposal. For example https://github.com/kubesphere/kubesphere/issues/3814

Please checkout [here](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/stage) if you wish to know more details about this plugin.