### PR TITLE
Add configuration for set merge method via label

### DIFF
--- a/ks-ci-bot/config.yaml
+++ b/ks-ci-bot/config.yaml
@@ -16,6 +16,10 @@
 #         command: ["/bin/printenv"]
 prowjob_namespace: "prow"
 tide:
+  blocker_label: tide/merge-blocker
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
   merge_method:
     kubesphere/s2ioperator: squash
     kubesphere/porterlb: squash

--- a/ks-ci-bot/plugins.yaml
+++ b/ks-ci-bot/plugins.yaml
@@ -549,3 +549,8 @@ project_manager:
               name: 'devops'
               org: 'kubesphere'
               state: 'open'
+label:
+  additional_labels:
+    - tide/merge-method-merge
+    - tide/merge-method-rebase
+    - tide/merge-method-squash


### PR DESCRIPTION
If you want to let a PR merge and squash. Please see also the following usage:

```
/label tide/merge-method-squash
```